### PR TITLE
conda install instructions

### DIFF
--- a/forest-modelling-treecrown_deepforest.ipynb
+++ b/forest-modelling-treecrown_deepforest.ipynb
@@ -61,6 +61,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "pip install method"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -77,6 +84,37 @@
     "!pip -q install torch==1.9.0\n",
     "!pip -q install DeepForest==1.0.0\n",
     "!pip -q install geoviews"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "conda install method - if you are working from a local machine and use anaconda to manage your python libraries and dependencies, run this code in the CLI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "alternatively, use [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) - a faster package manager that works within conda environments"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "conda create -n environmentname\n",
+    "conda activate environmentname\n",
+    "conda install -c pytorch python=3 pytorch torchvision\n",
+    "conda install -c conda-forge deepforest albumentations intake pooch hvplot ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "load libraries"
    ]
   },
   {
@@ -754,7 +792,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.10.5 ('cambridge')",
    "language": "python",
    "name": "python3"
   },
@@ -768,7 +806,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "23b898eebe366e995761645ea18b9a146c1ce07ba209fcc9c737b6396bdb63ae"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added conda instructions for those that use conda instead of pip. Additionally, added intake pooch hvplot ipywidgets as explicit installs as conda does not install. Unsure if pip does this or was just missing. Great notebook by the way!